### PR TITLE
Permanently cede control to delegate gems instead of returning to learn-co

### DIFF
--- a/bin/learn
+++ b/bin/learn
@@ -30,7 +30,7 @@ netrc.read
 token = netrc.password
 
 if !LEARN_CONFIG_COMMANDS.include?(ARGV[0]) && (token.nil? || token == 'machine' || !File.exist?(File.expand_path('~/.learn-config')))
-  system('learn-config') unless Learn::InternetConnection.no_internet_connection?
+  exec('learn-config') unless Learn::InternetConnection.no_internet_connection?
 end
 
 if INTERNET_REQUIRED_COMMANDS.include?(ARGV[0])

--- a/lib/learn/cli.rb
+++ b/lib/learn/cli.rb
@@ -17,7 +17,7 @@ module Learn
       --fail-fast           # Stop running rspec test suite on first failed test
     LONGDESC
     def test(*opts)
-      system("learn-test #{opts.join(' ')}")
+      exec("learn-test #{opts.join(' ')}")
     end
 
     desc 'version, -v, --version', 'Display the current version of the Learn gem'
@@ -42,7 +42,7 @@ module Learn
         options['message']
       end
 
-      system("learn-submit #{commit_message}")
+      exec("learn-submit #{commit_message}")
     end
 
     desc "open [lesson-name] [--editor=editor-binary]", "Open your current lesson [or the given lesson] [with your editor]"
@@ -60,7 +60,7 @@ module Learn
       lab_name = Learn::Lab::Parser.new(lab_name.join(' ')).parse!
       editor = options[:editor]
 
-      system("learn-open #{lab_name} --editor=#{editor}")
+      exec("learn-open #{lab_name} --editor=#{editor}")
     end
 
     desc "next [--editor=editor-binary]", "Open your next lesson [with your editor]"
@@ -68,27 +68,27 @@ module Learn
     def next
       editor = options[:editor]
 
-      system("learn-open --next --editor=#{editor}")
+      exec("learn-open --next --editor=#{editor}")
     end
 
     desc 'whoami', 'Display your Learn gem configuration information'
     def whoami
-      system('learn-config --whoami')
+      exec('learn-config --whoami')
     end
 
     desc 'reset', 'Reset your Learn gem configuration'
     def reset
-      system('learn-config --reset')
+      exec('learn-config --reset')
     end
 
     desc 'directory', 'Set your local Learn directory. Defaults to ~/Development/code'
     def directory
-      system('learn-config --set-directory')
+      exec('learn-config --set-directory')
     end
 
     desc 'doctor', 'Check your local environment setup'
     def doctor
-      system('learn-doctor')
+      exec('learn-doctor')
     end
 
     desc 'new lab-name -t|--template template-name', 'Generate a new lesson repo using a Learn.co template', hide: true
@@ -100,10 +100,10 @@ module Learn
       list = options[:list]
 
       if list
-        system("learn-generate --list #{has_internet ? '--internet' : ''}")
+        exec("learn-generate --list #{has_internet ? '--internet' : ''}")
       else
         if template && template != 'template'
-          system("learn-generate #{template} #{lab_name.join} #{has_internet ? '--internet' : ''}")
+          exec("learn-generate #{template} #{lab_name.join} #{has_internet ? '--internet' : ''}")
         else
           puts "You must specify a template with -t or --template"
           exit
@@ -113,25 +113,25 @@ module Learn
 
     desc 'status', 'Get the status of your current lesson'
     def status
-      system('learn-status')
+      exec('learn-status')
     end
 
     desc 'hello', 'Verify your connection to Learn.co'
     def hello
-      system('learn-hello')
+      exec('learn-hello')
     end
 
     desc 'lint', 'Lint a directory for correct content', hide: true
     def lint(dir=nil, quiet=nil)
       if dir && !quiet
-        system("learn-lint #{dir}")
+        exec("learn-lint #{dir}")
       elsif dir && quiet
-        system("learn-lint #{dir} #{quiet}")
+        exec("learn-lint #{dir} #{quiet}")
       elsif !dir && quiet
-        system("learn-lint #{quiet}")
+        exec("learn-lint #{quiet}")
       else
         current_dir = Dir.pwd
-        system("learn-lint #{current_dir}")
+        exec("learn-lint #{current_dir}")
       end
     end
 


### PR DESCRIPTION
Use `Kernel#exec` instead of `Kernel#system`. Once the `learn-co` gem cedes control to one of its subsidiary gems, there's no reason to ever return control to `learn-co`. It only adds overhead and, in the case of the new `learn-test` in-browser Mocha tests, causes an ugly stack trace upon exiting the Browsersync server.

I switched all but two `#system`s over to `#exec`. The two I left untouched:
```ruby
# lib/learn/cli.rb
def save
  if !system('learn-submit --save-only')
    exit 1
  end
end
```

```ruby
# lib/learn/netrc_interactor.rb

def ensure_proper_permissions!
  system('chmod 0600 ~/.netrc &>/dev/null')
end
```

Both of those require control to be returned to `learn-co` after they finish executing — the first because it's checking the truthiness of the return value, and the second because of potential chaining off of `Learn::NetrcInteractor.new`.

@joshrowley @StevenNunez I added twiddle-wakas to the gemspec dependencies to silence Bundler warnings. The only major change is switching the `learn-test` and `learn-submit` dependencies from `"2.5.0"` to `">= 2.5.0"` and `"1.3.1"` to `">= 1.3.1"`, respectively. Any reason to keep those two fixed instead of allowing them to be open-ended assuming semver?