### PR TITLE
Remove learn-doctor

### DIFF
--- a/bin/learn
+++ b/bin/learn
@@ -3,11 +3,11 @@
 require 'learn'
 
 NON_PRE_CONFIG_COMMANDS = [
-  'reset', 'whoami', 'directory', 'help', 'version', '--version', '-v', 'doctor', 'new', 'hello', 'lint', 'save'
+  'reset', 'whoami', 'directory', 'help', 'version', '--version', '-v', 'new', 'hello', 'lint', 'save'
 ]
 
 INTERNET_REQUIRED_COMMANDS = [
-  'whoami', 'doctor', 'directory', 'reset', 'hello'
+  'whoami', 'directory', 'reset', 'hello'
 ]
 
 LEARN_CONFIG_COMMANDS = ['reset', 'whoami', 'directory']

--- a/learn-co.gemspec
+++ b/learn-co.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "learn-config", ">= 1.0.77"
   spec.add_runtime_dependency "learn-open", ">= 1.2.1"
   spec.add_runtime_dependency "learn-submit", "1.3.1"
-  spec.add_runtime_dependency "learn-doctor", ">= 1.0.3"
   spec.add_runtime_dependency "learn-generate", ">= 1.0.16"
   spec.add_runtime_dependency "learn-status", ">= 1.0.1"
   spec.add_runtime_dependency "learn-hello", ">= 1.0.1"

--- a/lib/learn/cli.rb
+++ b/lib/learn/cli.rb
@@ -86,11 +86,6 @@ module Learn
       exec('learn-config --set-directory')
     end
 
-    desc 'doctor', 'Check your local environment setup'
-    def doctor
-      exec('learn-doctor')
-    end
-
     desc 'new lab-name -t|--template template-name', 'Generate a new lesson repo using a Learn.co template', hide: true
     option :template, required: false, type: :string, aliases: ['t']
     option :list, required: false, type: :boolean

--- a/lib/learn/options_sanitizer.rb
+++ b/lib/learn/options_sanitizer.rb
@@ -19,7 +19,6 @@ module Learn
       'whoami',
       'directory',
       'next',
-      'doctor',
       'new',
       'status',
       'lint',

--- a/lib/learn/version.rb
+++ b/lib/learn/version.rb
@@ -1,3 +1,3 @@
 module Learn
-  VERSION = '3.8.4'
+  VERSION = '3.8.5'
 end


### PR DESCRIPTION
This command was tied to the Environmentalizer OSX app that is now deprecated.

See [jira ticket](https://flatiron.atlassian.net/projects/TS/issues/TS-624).